### PR TITLE
Reduce mvn verbosity on GitHub actions

### DIFF
--- a/.github/workflows/maven_tests.yml
+++ b/.github/workflows/maven_tests.yml
@@ -70,7 +70,7 @@ jobs:
       ### -P,--activate-profiles : Comma-delimited list of profiles to activate
       ### AlsoSlowTests : by default, only quick tests are run - the profile `AlsoSlowTests` runs the full test suite
       - name: Test with Maven (incl. slow tests)
-        run: mvn --errors clean test --activate-profiles AlsoSlowTests
+        run: ./mvnw -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -B --errors clean test --activate-profiles AlsoSlowTests
 
 
       - name: CodeCov - JavaParser Core

--- a/.github/workflows/maven_tests.yml
+++ b/.github/workflows/maven_tests.yml
@@ -70,6 +70,7 @@ jobs:
       ### -P,--activate-profiles : Comma-delimited list of profiles to activate
       ### AlsoSlowTests : by default, only quick tests are run - the profile `AlsoSlowTests` runs the full test suite
       - name: Test with Maven (incl. slow tests)
+        shell: bash
         run: ./mvnw -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -B --errors clean test --activate-profiles AlsoSlowTests
 
 


### PR DESCRIPTION
This removes the progress output and makes the output much shorter.

Inspired by: https://stackoverflow.com/a/35653426/873282